### PR TITLE
This fixes a crash when there are zero messages in a chat or if this is the start of a new chat

### DIFF
--- a/Chirp/Pages/Messages/MessagesViewController.swift
+++ b/Chirp/Pages/Messages/MessagesViewController.swift
@@ -225,7 +225,9 @@ extension MessagesViewController: UITextViewDelegate {
     }
     
     private func scrollMessagesToBottom(animate: Bool = true) {
-        self.tableView.scrollToRow(at: IndexPath(row: self.viewModel.messages.value.count - 1, section: 0), at: .bottom, animated: animate)
+        if self.viewModel.messages.value.count != 0 {
+            self.tableView.scrollToRow(at: IndexPath(row: self.viewModel.messages.value.count - 1, section: 0), at: .bottom, animated: animate)
+        }
     }
 }
 


### PR DESCRIPTION
### What does this PR do?
This PR fixes a crash when we start a new chat (zero messages in the chat)

### Description of tasks to be completed


### How to manually test
- Pick a new user with whom you have not started a chat
- Try tapping on the text field, it should't crash the app

### Any background context you want to provide


### Screenshots
